### PR TITLE
fix: add scroll-to-top functionality across all pages #117

### DIFF
--- a/client/src/components/scrolltotop.js
+++ b/client/src/components/scrolltotop.js
@@ -1,16 +1,45 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 
 export default function ScrollToTop() {
   const { pathname } = useLocation();
+  const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: "smooth"
-    });
+    window.scrollTo({ top: 0, left: 0, behavior: "smooth" });
   }, [pathname]);
 
-  return null;
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > 300);
+    };
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <button
+      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      style={{
+        position: "fixed",
+        bottom: "2rem",
+        right: "2rem",
+        zIndex: 9999,
+        backgroundColor: "#4f46e5",
+        color: "white",
+        border: "none",
+        borderRadius: "50%",
+        width: "44px",
+        height: "44px",
+        fontSize: "1.2rem",
+        cursor: "pointer",
+        boxShadow: "0 4px 12px rgba(0,0,0,0.2)",
+      }}
+      aria-label="Scroll to top"
+    >
+      ↑
+    </button>
+  );
 }


### PR DESCRIPTION
Closes #117

## Changes made
- Added visible scroll to top button in scrolltotop.js
- Button appears on all pages when user scrolls down 300px
- Smooth scroll animation on click
- Auto scrolls to top on every page navigation