### PR TITLE
Fix typo in syallabus page content

### DIFF
--- a/client/src/pages/Syllabus.js
+++ b/client/src/pages/Syllabus.js
@@ -226,7 +226,7 @@ const [showScroll, setShowScroll] = useState(false);
             <motion.div className="hero-stats" variants={staggerChildren}>
               <motion.div className="hero-stat" variants={scaleIn}>
                 <span className="stat-number">{syllabusData.length}</span>
-                <span className="stat-label">Syllabi Available</span>
+                <span className="stat-label">Syllabus Available</span>
               </motion.div>
               <motion.div className="hero-stat" variants={scaleIn}>
                 <span className="stat-number">{universities.length - 1}</span>
@@ -313,8 +313,8 @@ const [showScroll, setShowScroll] = useState(false);
       >
         <div className="container">
           <motion.div className="results-header" variants={fadeInUp}>
-            <h2>Found {filteredAndSortedSyllabi.length} syllabi</h2>
-            <p>Browse through our collection of verified academic syllabi</p>
+            <h2>Found {filteredAndSortedSyllabi.length} syllabus</h2>
+            <p>Browse through our collection of verified academic syllabus</p>
           </motion.div>
           
           <AnimatePresence>
@@ -326,7 +326,7 @@ const [showScroll, setShowScroll] = useState(false);
                 exit={{ opacity: 0, y: -30 }}
               >
                 <div className="no-results-icon">📭</div>
-                <h3>No syllabi found</h3>
+                <h3>No syllabus found</h3>
                 <p>Try adjusting your search criteria or filters to find what you're looking for.</p>
               </motion.div>
             ) : (


### PR DESCRIPTION
Fixed typo(s) on the syllabus page to improve readability and content accuracy.

Changes Made
- Corrected spelling/wording issue in the syllabus section. as there is a miswording of a sentence as found 8 syllabi which could have made confusion in reading and analyzing so it`s been changed to syllabus and throughout the page the syllabus word is  written as syllabi so this typo mistakes is been corrected.

This contribution is made under GSSoC`26

