### PR TITLE
Fix: Sort semester dropdown options in syllabus page (#216)

### DIFF
--- a/client/src/pages/Syllabus.js
+++ b/client/src/pages/Syllabus.js
@@ -162,8 +162,11 @@ const [showScroll, setShowScroll] = useState(false);
   // Get unique values for filters
   const universities = ['All', ...new Set(syllabusData.map(item => item.university))];
   const departments = ['All', ...new Set(syllabusData.map(item => item.department))];
-  const semesters = ['All', ...new Set(syllabusData.map(item => item.semester))];
-
+  const semesters = [
+  'All',
+  ...[...new Set(syllabusData.map(item => item.semester))]
+    .sort((a, b) => a - b)
+  ];
   // Filter and sort logic
   const filteredAndSortedSyllabi = useMemo(() => {
     let filtered = syllabusData.filter(item => {


### PR DESCRIPTION
## Description
Fixed the unordered semester dropdown options in the Syllabus page.

## Changes made
- Added sorting for semester dropdown values
- Ensured semesters are displayed in ascending order
- Improved consistency across university and department combinations

Fixes #216