### PR TITLE
Fix download button disabled state

### DIFF
--- a/client/src/pages/Analytics.js
+++ b/client/src/pages/Analytics.js
@@ -213,18 +213,21 @@ const Analytics = () => {
           viewport={{ once: true, margin: "-100px" }}
           variants={fadeInUp}
         >
-          <motion.button 
-            className="download-btn"
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              if (selectedSubject !== 'all') {
-                handleDownload(selectedSubject);
-              }
-            }}
-          >
-            ⬇️ Download Notes (PDF)
-          </motion.button>
+          <motion.button
+  className="download-btn"
+  disabled={selectedSubject === 'all'}
+  whileHover={{ scale: selectedSubject === 'all' ? 1 : 1.05 }}
+  whileTap={{ scale: selectedSubject === 'all' ? 1 : 0.95 }}
+  onClick={() => handleDownload(selectedSubject)}
+>
+  ⬇️ Download Notes (PDF)
+</motion.button>
+
+<p style={{ fontSize: '13px', color: 'var(--color-text-secondary)' }}>
+  {selectedSubject === 'all'
+    ? 'Select a subject above to download its notes'
+    : `Ready to download ${selectedSubject.toUpperCase()} notes`}
+</p>
         </motion.section>
       </div>
 


### PR DESCRIPTION
## What changed
- Disabled the Download Notes button when "All Subjects" is selected.
- Added helper text to guide users to select a subject before downloading.

## Why
Previously, clicking Download when "All Subjects" was selected did nothing and gave no feedback.

## Testing
- Ran npm run build successfully.
- Checked that the button is disabled when "All Subjects" is selected.
- Checked that the button works after selecting a subject.
-
Fixes #110 