### PR TITLE
feat: make feature cards fully clickable

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -259,10 +259,14 @@ const Home = () => {
                 linkText: "Read Feedback →"
               }
             ].map((feature, index) => (
-              <motion.div 
+              
+                 <motion.div
                 key={index}
                 className="feature-card"
                 variants={scaleIn}
+                onClick={() => window.location.href = feature.link}
+                style={{ cursor: "pointer" }}  
+
                 whileHover={{ 
                   scale: 1.05, 
                   y: -10,
@@ -288,8 +292,10 @@ const Home = () => {
                   </Link>
                 </motion.div>
               </motion.div>
+             
             ))}
           </motion.div>
+          
         </div>
       </motion.section>
 


### PR DESCRIPTION
## Description

Made homepage feature cards fully clickable instead of limiting navigation to only the inner text/button links.

## Changes Made

* Added click navigation to the entire feature card
* Improved user experience and accessibility
* Added pointer cursor for better visual feedback

## Issue

Closes #205
