### PR TITLE
feat: add reusable footer across multiple pages

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -1,0 +1,116 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaGithub, FaLinkedin, FaXTwitter, FaDiscord } from "react-icons/fa6";
+
+const Footer = () => {
+  return (
+    <footer className="footer">
+      <div className="container">
+        <div className="footer-content">
+
+          {/* Left Section */}
+          <div className="footer-section">
+            <p>
+              Empowering students with comprehensive academic resources
+              and peer-to-peer learning.
+            </p>
+
+            <div className="social-links">
+              <a
+                href="https://github.com/lovelymahor/StudyMatePlus"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-icon github"
+              >
+                <FaGithub />
+              </a>
+
+              <a
+                href="https://linkedin.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-icon linkedin"
+              >
+                <FaLinkedin />
+              </a>
+
+              <a
+                href="https://twitter.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-icon twitter"
+              >
+                <FaXTwitter />
+              </a>
+
+              <a
+                href="https://discord.com"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="social-icon discord"
+              >
+                <FaDiscord />
+              </a>
+            </div>
+          </div>
+
+          {/* Quick Links */}
+          <div className="footer-section">
+            <h4>Quick Links</h4>
+
+            <ul>
+              <li>
+                <Link to="/syllabus">Syllabus</Link>
+              </li>
+
+              <li>
+                <Link to="/pyqs">Previous Papers</Link>
+              </li>
+
+              <li>
+                <Link to="/feedback">Feedback</Link>
+              </li>
+
+              <li>
+                <Link to="/mentorship">Mentorship</Link>
+              </li>
+            </ul>
+          </div>
+
+          {/* Support Links */}
+          <div className="footer-section">
+            <h4>Support</h4>
+
+            <ul>
+              <li>
+                <Link to="/help">Help Center</Link>
+              </li>
+
+              <li>
+                <Link to="/contact">Contact Us</Link>
+              </li>
+
+              <li>
+                <Link to="/contribute">Contribute</Link>
+              </li>
+
+              <li>
+                <Link to="/privacy">Privacy Policy</Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Footer Bottom */}
+        <div className="footer-bottom">
+          <p>
+            &copy; {new Date().getFullYear()} StudyMatePlus.
+            Open-source educational platform for students.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/client/src/pages/Analytics.js
+++ b/client/src/pages/Analytics.js
@@ -9,6 +9,7 @@ import {
   Tooltip,
   Legend,
 } from 'chart.js';
+import Footer from "../components/Footer";
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaArrowUp } from "react-icons/fa";
 import './Analytics.css';
@@ -245,6 +246,7 @@ const Analytics = () => {
           </motion.button>
         )}
       </AnimatePresence>
+      <Footer/>
      </div>
    );
 };

--- a/client/src/pages/Feedback.js
+++ b/client/src/pages/Feedback.js
@@ -4,7 +4,7 @@ import "./Feedback.css";
 import './ScrollToTop.css';
 import { FaArrowUp } from "react-icons/fa";
 import FeedbackModal from "../components/FeedbackModal"; // Import the modal component
-
+import Footer from "../components/Footer";
 const Feedback = () => {
   const [selectedFilter, setSelectedFilter] = useState("all");
   const [selectedUniversity, setSelectedUniversity] = useState("all");
@@ -680,7 +680,7 @@ const Feedback = () => {
         {isModalOpen && <FeedbackModal onClose={closeModal} />}
       </AnimatePresence>
       {/* --- CORRECTED SECTION END --- */}
-
+      <Footer />
     </div>
   );
 };

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -259,10 +259,14 @@ const Home = () => {
                 linkText: "Read Feedback →"
               }
             ].map((feature, index) => (
-              <motion.div 
+              
+                 <motion.div
                 key={index}
                 className="feature-card"
                 variants={scaleIn}
+                onClick={() => window.location.href = feature.link}
+                style={{ cursor: "pointer" }}  
+
                 whileHover={{ 
                   scale: 1.05, 
                   y: -10,
@@ -288,8 +292,10 @@ const Home = () => {
                   </Link>
                 </motion.div>
               </motion.div>
+             
             ))}
           </motion.div>
+          
         </div>
       </motion.section>
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaGithub, FaLinkedin, FaDiscord, FaArrowUp } from "react-icons/fa";
 import { FaXTwitter } from "react-icons/fa6";
+import Footer from "../components/Footer";
 import logo from "./logo.png";
 import "./Home.css";
 import './ScrollToTop.css';
@@ -598,82 +599,7 @@ const Home = () => {
         </div>
       </motion.section>
 
-      {/* Footer */}
-      <motion.footer 
-        className="footer"
-        initial="hidden"
-        whileInView="visible"
-        viewport={{ once: true, margin: "-50px" }}
-        variants={fadeInUp}
-      >
-        <div className="container">
-          <motion.div className="footer-content" variants={staggerChildren}>
-            {/* Left Section */}
-            <motion.div className="footer-section" variants={slideInLeft}>
-              <img 
-                src={logo} 
-                alt="StudyMatePlus Logo" 
-                style={{ height: "50px", marginBottom: "10px" }} 
-              />
-              <p>Empowering students with comprehensive academic resources and peer-to-peer learning.</p>
-              {/* Social Links with Icons */}
-              <div className="social-links">
-                <a href="https://github.com/lovelymahor/StudyMatePlus" target="_blank" rel="noopener noreferrer" className="social-icon github">
-                  <FaGithub />
-                </a>
-                <a href="https://linkedin.com" target="_blank" rel="noopener noreferrer" className="social-icon linkedin">
-                  <FaLinkedin />
-                </a>
-                <a href="https://twitter.com" target="_blank" rel="noopener noreferrer" className="social-icon twitter">
-                  <FaXTwitter />
-                </a>
-                <a href="https://discord.com" target="_blank" rel="noopener noreferrer" className="social-icon discord">
-                  <FaDiscord />
-                </a>
-              </div>
-            </motion.div>
-
-            {/* Quick Links */}
-            <motion.div className="footer-section" variants={fadeInUp}>
-              <h4>Quick Links</h4>
-              <motion.ul variants={staggerChildrenFast}>
-                {[
-                  { to: "/syllabus", text: "Syllabus" },
-                  { to: "/pyqs", text: "Previous Papers" },
-                  { to: "/feedback", text: "Feedback" },
-                  { to: "/mentorship", text: "Mentorship" }
-                ].map((link, index) => (
-                  <motion.li key={index} variants={fadeInUp} whileHover={{ x: 5, color: "#3b82f6" }}>
-                    <Link to={link.to}>{link.text}</Link>
-                  </motion.li>
-                ))}
-              </motion.ul>
-            </motion.div>
-
-            {/* Support Links */}
-            <motion.div className="footer-section" variants={slideInRight}>
-              <h4>Support</h4>
-              <motion.ul variants={staggerChildrenFast}>
-                {[
-                  { to: "/help", text: "Help Center" },
-                  { to: "/contact", text: "Contact Us" },
-                  { to: "/contribute", text: "Contribute" },
-                  { to: "/privacy", text: "Privacy Policy" }
-                ].map((link, index) => (
-                  <motion.li key={index} variants={fadeInUp} whileHover={{ x: 5, color: "#3b82f6" }}>
-                    <Link to={link.to}>{link.text}</Link>
-                  </motion.li>
-                ))}
-              </motion.ul>
-            </motion.div>
-          </motion.div>
-
-          {/* Footer Bottom */}
-          <motion.div className="footer-bottom" variants={fadeInUp}>
-            <p>&copy; {new Date().getFullYear()} StudyMatePlus. Open-source educational platform for students.</p>
-          </motion.div>
-        </div>
-      </motion.footer>
+       <Footer />
 
       {/* Scroll to Top Button */}
       <AnimatePresence>

--- a/client/src/pages/MindMapEditor.js
+++ b/client/src/pages/MindMapEditor.js
@@ -8,7 +8,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import './MindMapEditor.css';
 import './ScrollToTop.css';
-
+import Footer from "../components/Footer";
 import { v4 as uuid } from 'uuid';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Layers, Moon, Sun, Download, Upload, Save, Plus, Trash2 } from 'lucide-react';
@@ -782,6 +782,7 @@ export default function MindMapEditor() {
           </motion.button>
         )}
       </AnimatePresence>
+      <Footer/>
    </div>
  );
 }

--- a/client/src/pages/Notes.jsx
+++ b/client/src/pages/Notes.jsx
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaArrowUp } from "react-icons/fa";
 import './Notes.css';
-
+import Footer from "../components/Footer";
 const Notes = () => {
   const fileInputRef = useRef(null);
   
@@ -419,6 +419,7 @@ const handleDownload = (e, note) => {
           </motion.button>
         )}
       </AnimatePresence>
+      <Footer/>
    </div>
  );
 };

--- a/client/src/pages/PYQs.js
+++ b/client/src/pages/PYQs.js
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { FaArrowUp } from "react-icons/fa";
 import "./PYQs.css";
 import './ScrollToTop.css';
-
+import Footer from "../components/Footer";
 const PYQs = () => {
   // Animation Variants from Home.js
   const fadeInUp = {
@@ -243,6 +243,7 @@ const scrollToTop = () => {
           </motion.button>
         )}
       </AnimatePresence>
+      <Footer />
     </div>
   );
 };

--- a/client/src/pages/Syllabus.js
+++ b/client/src/pages/Syllabus.js
@@ -2,7 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { FaArrowUp } from "react-icons/fa";
 import './Syllabus.css';
-
+import Footer from "../components/Footer";
 const Syllabus = () => {
   // Mock data for syllabi
   const syllabusData = [
@@ -437,6 +437,7 @@ const [showScroll, setShowScroll] = useState(false);
                 </motion.button>
               )}
             </AnimatePresence>
+            <Footer />
     </div>
   );
 };


### PR DESCRIPTION
## Description

Added a reusable Footer component and integrated it across multiple pages including Syllabus, Notes, PYQs, Analytics, Mind Map, and Feedback pages.

## Changes Made

* Created reusable `Footer` component
* Removed duplicated footer code from Home page
* Added footer across multiple pages for consistent UI/UX
* Improved code reusability and maintainability

## Issue

Closes #347
