### PR TITLE
Fix: Update GSSoC year from 2025 to 2026 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ npm start           # Runs React frontend on localhost:3000
 ---
 
 ## 🧑‍💻 How to Contribute
-
-We welcome contributors of **all experience levels**, especially **beginners** participating through **GirlScript Summer of Code (GSSoC) 2025** and beyond.
+<!-- Fix: Updated GSSoC year from 2025 to 2026 -->
+We welcome contributors of **all experience levels**, especially **beginners** participating through **GirlScript Summer of Code (GSSoC) 2026** and beyond.
 
 Follow the steps below to begin your contribution journey:
 


### PR DESCRIPTION
## Description
Fixed outdated GSSoC year reference in README.md.

The contributing section mentioned "GirlScript Summer of Code 
(GSSoC) 2025" which is outdated. The current program is 
GSSoC 2026.

Fixed by updating the year from 2025 to 2026.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Changes Made
| File | Change |
|------|--------|
| `README.md` | Updated GSSoC year from 2025 to 2026 |

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes do not break any existing functionality
- [x] I have tested changes locally