### PR TITLE
fix: improve footer readability in light mode

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -724,7 +724,7 @@ html[data-theme="dark"] .footer-section h4 { color: #fbbf24; }
 .footer-section p {
   max-width: 300px;
   line-height: 1.7;
-  color: var(--muted);
+  color: #cbd5e1;
   font-size: 0.95rem;
 }
 
@@ -737,7 +737,7 @@ html[data-theme="dark"] .footer-section h4 { color: #fbbf24; }
 }
 
 .footer-section a {
-  color: var(--muted);
+  color: #cbd5e1;
   text-decoration: none;
   font-size: 0.95rem;
   transition: color 0.2s ease;
@@ -779,7 +779,7 @@ html[data-theme="dark"] .footer-section h4 { color: #fbbf24; }
   border-top: 1px solid var(--border);
   text-align: center;
   font-size: 0.88rem;
-  color: var(--muted);
+  color: #cbd5e1;
 }
 
 /* ============================================================


### PR DESCRIPTION
## Description
Improved footer readability in Light Mode by updating footer text and link colors to ensure proper contrast against the footer background.

## Changes Made
- Fixed footer description text visibility
- Fixed footer links visibility
- Fixed footer copyright text visibility
- Verified that Dark Mode remains unaffected

## Issue
Fixes #491

## Type of Change
- [x] Bug Fix

## Screenshots
Before: Footer text was difficult to read in Light Mode.
After: Footer text and links are clearly visible in Light Mode.