### PR TITLE
fix: add per-page document titles for better UX and SEO

### DIFF
--- a/client/src/pages/About.js
+++ b/client/src/pages/About.js
@@ -5,6 +5,7 @@ import { FaArrowUp } from "react-icons/fa";
 import './About.css';
 import './ScrollToTop.css';
 const About = () => {
+  document.title = "StudyMatePlus | About Us";
   // Animation Variants from Home.js
   const fadeInUp = {
     hidden: { opacity: 0, y: 40 },

--- a/client/src/pages/Analytics.js
+++ b/client/src/pages/Analytics.js
@@ -17,6 +17,7 @@ import './ScrollToTop.css';
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Tooltip, Legend);
 
 const Analytics = () => {
+  document.title = "StudyMatePlus | Analytics";
   // Animation Variants
   const fadeInUp = {
     hidden: { opacity: 0, y: 40 },

--- a/client/src/pages/Contact.js
+++ b/client/src/pages/Contact.js
@@ -4,6 +4,9 @@ import './Contact.css';
 import './ScrollToTop.css';
 
 const Contact = () => {
+
+  document.title = "StudyMatePlus | Contribute";
+
   const [formData, setFormData] = useState({
     name: '',
     email: '',

--- a/client/src/pages/Faq.js
+++ b/client/src/pages/Faq.js
@@ -57,6 +57,9 @@ import { FaXTwitter } from "react-icons/fa6";
   };
 
 const Faq = () => {
+
+  document.title = "StudyMatePlus | FAQs";
+
   const [openIndex, setOpenIndex] = useState(null);
   const [showScroll, setShowScroll] = useState(false);
 

--- a/client/src/pages/Feedback.js
+++ b/client/src/pages/Feedback.js
@@ -6,6 +6,8 @@ import { FaArrowUp } from "react-icons/fa";
 import FeedbackModal from "../components/FeedbackModal"; // Import the modal component
 
 const Feedback = () => {
+
+  document.title = "StudyMatePlus | Feedback";
   const [selectedFilter, setSelectedFilter] = useState("all");
   const [selectedUniversity, setSelectedUniversity] = useState("all");
   const [showScroll, setShowScroll] = useState(false);

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -9,6 +9,8 @@ import "./Home.css";
 import './ScrollToTop.css';
 
 const Home = () => {
+
+  document.title = "StudyMatePlus | Home";
   const [contributors, setContributors] = useState([]);
   const [showScroll, setShowScroll] = useState(false);
 

--- a/client/src/pages/MindMapEditor.js
+++ b/client/src/pages/MindMapEditor.js
@@ -82,6 +82,7 @@ function computeHiddenTargets(collapsedIds, edges) {
 }
 
 export default function MindMapEditor() {
+    document.title = "StudyMatePlus | Mind Map";
   const [dark, setDark] = useState(false);
   const [search] = useState('');
 

--- a/client/src/pages/Notes.jsx
+++ b/client/src/pages/Notes.jsx
@@ -4,6 +4,8 @@ import { FaArrowUp } from "react-icons/fa";
 import './Notes.css';
 
 const Notes = () => {
+
+  document.title = "StudyMatePlus | Notes";
   const fileInputRef = useRef(null);
   
   // Dynamic state initialized with mock data as fallback

--- a/client/src/pages/PYQs.js
+++ b/client/src/pages/PYQs.js
@@ -5,6 +5,8 @@ import "./PYQs.css";
 import './ScrollToTop.css';
 
 const PYQs = () => {
+
+  document.title = "StudyMatePlus | PYQs";
   // Animation Variants from Home.js
   const fadeInUp = {
     hidden: { opacity: 0, y: 40 },

--- a/client/src/pages/Privacy.js
+++ b/client/src/pages/Privacy.js
@@ -4,6 +4,8 @@ import './Privacy.css';
 import './ScrollToTop.css';
 
 const Privacy = () => {
+
+  document.title = "StudyMatePlus | Privacy Policy";
   return (
     <div className="privacy">
       {/* Hero Section */}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -17,6 +17,8 @@ const user = {
 };
 
 const Profile = () => {
+
+  document.title = "StudyMatePlus | Profile";
   const [activeTab, setActiveTab] = useState("uploads");
 
   const fadeInUp = {

--- a/client/src/pages/Syllabus.js
+++ b/client/src/pages/Syllabus.js
@@ -4,6 +4,8 @@ import { FaArrowUp } from "react-icons/fa";
 import './Syllabus.css';
 
 const Syllabus = () => {
+
+  document.title = "StudyMatePlus | Syllabus";
   // Mock data for syllabi
   const syllabusData = [
     {

--- a/client/src/pages/Todo.js
+++ b/client/src/pages/Todo.js
@@ -19,6 +19,7 @@ function addIntervalToDate(iso, recurrence) {
 }
 
 export default function Todo() {
+   document.title = "StudyMatePlus | Todo";
   const [tasks, setTasks] = useState([]);
   const [form, setForm] = useState(defaultForm);
   const [isEditing, setIsEditing] = useState(false);


### PR DESCRIPTION
## 🐛 Fix: Add Per-Page Document Titles

Closes #499

## Problem
Every page showed the same generic "StudyMatePlus" title in the browser tab. No per-page titles which hurts both UX and SEO.

## Solution
- Added `document.title` to all 14 page components
- Also removed duplicate `/privacy` route in `App.js`

## Pages Updated
- Home, Syllabus, Notes, PYQs, Feedback, About
- Contact, Contribute, FAQ, Privacy, Profile
- MindMap, Todo, SubmitFeedback, Analytics

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1c9a72b0-b3b1-456f-8d3e-940b540c2c83" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a0936711-3db7-4997-ad49-c394305aeb67" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/585ac202-f67a-4f2e-a9ac-c7ca01ea96be" />


## Type of Change
- [x] Bug fix
- [x] UX improvement
- [x] SEO improvement