### PR TITLE
fix: improve values section card layout on desktop (#505)

### DIFF
--- a/client/src/pages/About.css
+++ b/client/src/pages/About.css
@@ -279,7 +279,7 @@
 
 .values-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
 }
 


### PR DESCRIPTION
## Related Issue

Closes #505

## Summary

Improved the Values section layout on desktop screens by arranging the six value cards into a balanced 3×2 grid.

## Changes Made

* Updated the desktop grid layout for the Values section.
* Improved visual balance and spacing between cards.
* Preserved existing tablet and mobile responsiveness.

## Before

The Values section displayed cards in an uneven layout on desktop screens, creating unnecessary empty space and reducing visual consistency.

## After

The Values section now displays six cards in a balanced 3×2 grid, providing a cleaner and more organized appearance on desktop devices.

## Type of Change

* [x] UI Enhancement
* [ ] Bug Fix
* [ ] New Feature

## Screenshots

### Before

<img width="1745" height="775" alt="Screenshot 2026-06-11 124719" src="https://github.com/user-attachments/assets/3c9b6251-78f9-4c42-8bef-79b20fce154d" />

### After

<img width="1596" height="777" alt="Screenshot 2026-06-11 141155" src="https://github.com/user-attachments/assets/4ca6d220-e029-4b6f-9101-c1eaf5815d44" />
