### PR TITLE
fix: resolve timezone shifting bug in Todo deadline #488

### DIFF
--- a/client/src/pages/Todo.js
+++ b/client/src/pages/Todo.js
@@ -2,6 +2,14 @@ import React, { useEffect, useState } from "react";
 import "./Todo.css";
 import Calendar from "../components/Calendar";
 
+function toLocalDatetimeInputValue(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const offset = d.getTimezoneOffset();
+  const local = new Date(d.getTime() - offset * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
 const STORAGE_KEY = "smp_tasks_v1";
 
 const defaultForm = { id: null, title: "", description: "", deadline: "", recurrence: "none" };
@@ -197,7 +205,7 @@ export default function Todo() {
                   Deadline
                   <input
                     type="datetime-local"
-                        value={form.deadline ? new Date(form.deadline).toISOString().slice(0,16) : ''}
+                        value={form.deadline ? toLocalDatetimeInputValue(form.deadline) : ''}
                         onChange={(e) => {
                           const v = e.target.value; // yyyy-mm-ddThh:mm
                           const iso = v ? new Date(v).toISOString() : '';


### PR DESCRIPTION
 @lovelymahor  ## Fixes #488

### Problem
The `datetime-local` input in the Todo form displayed the deadline using `.toISOString().slice(0,16)`, which converts the stored time to UTC. Since `datetime-local` inputs expect a local time string (no timezone info), this caused the displayed time to shift backward by the local timezone offset (e.g., 5.5 hours for GMT+5:30). Saving this shifted value repeatedly caused the deadline to drift further back on every edit.

### Fix
Added a `toLocalDatetimeInputValue()` helper function that converts the stored UTC ISO timestamp back to the correct local time for display in the `datetime-local` input, compensating for the timezone offset. The save logic (`new Date(value).toISOString()`) was already correct and required no change.

### Changes
- Added `toLocalDatetimeInputValue(iso)` helper in `Todo.js`
- Updated the `datetime-local` input's `value` prop to use this helper instead of `.toISOString().slice(0,16)`

### Testing
- Created a task with a specific deadline time
- Edited the task and confirmed the displayed time matches the original (no shift)
- Saved and re-edited multiple times — deadline remains stable, no cumulative drift

### Note
Existing unrelated build errors in `Navbar.css`, `Home.js`, and `Profile.js` were present on `main` before this change and are out of scope for this PR.