### PR TITLE
feat: add floating "scroll-to-top button" with smooth scrolling

### DIFF
--- a/client/src/components/scrolltotop.js
+++ b/client/src/components/scrolltotop.js
@@ -1,16 +1,56 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import "../pages/ScrollToTop.css";
 
 export default function ScrollToTop() {
   const { pathname } = useLocation();
+  const [isVisible, setIsVisible] = useState(false);
 
+  // Existing route-change behavior
   useEffect(() => {
     window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: "smooth"
+      top: 0,
+      left: 0,
+      behavior: "smooth",
     });
   }, [pathname]);
 
-  return null;
+  // Show button after scrolling 300px
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+
+    return () => {
+      window.removeEventListener("scroll", toggleVisibility);
+    };
+  }, []);
+
+  // Scroll back to top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  return (
+    <>
+      {isVisible && (
+        <button
+          className="scroll-to-top"
+          onClick={scrollToTop}
+          aria-label="Scroll to top"
+        >
+          ↑
+        </button>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
Closes #608 

## Summary
Added a floating Scroll-to-Top button that appears after the user scrolls down and smoothly scrolls the page back to the top when clicked.

## Changes Made

- Added floating scroll-to-top button
- Implemented smooth scrolling behavior
- Added visibility toggle based on scroll position
- Added responsive styling
- Added accessibility support using aria-label

## Testing

- Tested on Home page
- Tested on PYQs page
- Tested on Syllabus page
- Verified smooth scrolling functionality
- Verified responsive behavior on different screen sizes

Screenshots and screen-recordings of the working are attached below.

<img width="1898" height="912" alt="Screenshot 2026-06-24 213308" src="https://github.com/user-attachments/assets/69f58d44-e99e-4590-86e1-56df908da1bb" />

<img width="1912" height="911" alt="Screenshot 2026-06-24 213325" src="https://github.com/user-attachments/assets/5805d829-7f57-476d-95fe-0af205dd000b" />

https://github.com/user-attachments/assets/610469f4-7ede-47c1-b1b1-34599596e924

