### PR TITLE
Fix #609: Make support email clickable in Contact and FAQ sections

### DIFF
--- a/client/src/pages/Contact.js
+++ b/client/src/pages/Contact.js
@@ -111,7 +111,7 @@ const Contact = () => {
                 <div className="info-icon">📧</div>
                 <div className="info-content">
                   <h3>Email</h3>
-                  <p>support@studymateplus.com</p>
+                  <p><a href="mailto:support@studymateplus.com">support@studymateplus.com</a></p>
                 </div>
               </div>
               
@@ -171,7 +171,7 @@ const Contact = () => {
             
             <div className="faq-item">
               <h3>How do I report a problem?</h3>
-              <p>Use the contact form above or email us directly at support@studymateplus.com</p>
+              <p>Use the contact form above or email us directly at <a href="mailto:support@studymateplus.com">support@studymateplus.com</a></p>
             </div>
           </div>
         </div>

--- a/client/src/pages/Faq.js
+++ b/client/src/pages/Faq.js
@@ -86,7 +86,7 @@ const Faq = () => {
     },
     {
       q: "❓ How can I contact support?",
-      a: "Reach out to us via the Contact section at the bottom of the page or email support@studymateplus.com."
+      a: <>Reach out to us via the Contact section at the bottom of the page or email <a href="mailto:support@studymateplus.com">support@studymateplus.com</a>.</>
     }
   ];
 
@@ -170,7 +170,7 @@ const Faq = () => {
       <section className="contact-section container">
         <h2 className="section-title">📩 Contact Us</h2>
         <p>
-          Still have questions? Reach out to us at <b>support@studymateplus.com</b> or fill out the form below.
+          Still have questions? Reach out to us at <b><a href="mailto:support@studymateplus.com">support@studymateplus.com</a></b> or fill out the form below.
         </p>
         <form className="contact-form">
           <input type="text" placeholder="Your Name" required />


### PR DESCRIPTION
To resolve issue #609, I made the following modifications across the Contact.js and Faq.js pages:

Contact Us Section: Wrapped the plain text support@studymateplus.com with a standard mailto: hyperlink (<a href="mailto:support@studymateplus.com">).
FAQ Answers: Modified the string answers that reference the support email to be React fragments containing the clickable mailto: hyperlink.
Contact Forms (FAQ Page): Updated the plain text email address above the contact form to also use the same mailto: hyperlink.
Now, whenever a user clicks on the email address in any of these sections, their default mail client (like Outlook or Apple Mail) will automatically open and start composing a new email to the support team, dramatically improving user experience!

