### PR TITLE
fix: align hero CTA buttons vertically

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -595,8 +595,10 @@ html[data-theme="dark"] .step { background: #101826; }
 
 .cta-buttons {
   display: flex;
+  flex-direction: column; /* Changed: Make buttons stack vertically on all screen sizes */
+  align-items: center;   /* Changed: Center buttons horizontally on all screen sizes */
   gap: 1rem;
-  justify-content: center;
+  justify-content: center; /* Keep for vertical alignment if container has extra space */
   flex-wrap: wrap;
 }
 


### PR DESCRIPTION
## 📌 Description

This PR improves the presentation of the Call-to-Action (CTA) buttons in the Hero section by arranging them in a vertically centered layout.

Previously, the "Get Started" and "Learn More" buttons appeared side by side with inconsistent visual alignment, making the CTA section look slightly unbalanced. This update stacks the buttons vertically, resulting in a cleaner and more organized appearance while preserving the existing functionality and responsiveness.

## 🔗 Related Issue

Closes #628 

## ✨ Changes Made

* Updated the Hero section CTA button layout.
* Arranged the CTA buttons in a vertically centered stack.
* Improved the visual consistency of the Hero section.
* Preserved the existing functionality and responsive behavior.

## 🧪 Testing

* [x] Tested on Desktop
* [x] Tested on Tablet
* [x] Tested on Mobile
* [x] Verified that no functionality was affected

## 📸 Screenshots

### Before

<img width="1274" height="650" alt="Screenshot (1242)" src="https://github.com/user-attachments/assets/3fa0d1c0-a558-478a-8fb9-6d97b42fd6af" />

### After

<img width="1271" height="645" alt="Screenshot (1251)" src="https://github.com/user-attachments/assets/afe1a120-624b-4e7f-afb7-ebb00b7b9ca1" />

## Checklist

* [x] Code follows the project's coding style.
* [x] Tested the changes locally.
* [x] No unrelated files were modified.
* [x] This PR addresses a single UI enhancement.
