### PR TITLE
fix: speed up feature card hover transition to 200ms ease-out (#625)

### DIFF
--- a/client/src/pages/Home.css
+++ b/client/src/pages/Home.css
@@ -290,7 +290,7 @@ html[data-theme="dark"] .section-title { color: #ffffff; }
   text-align: center;
   border: 1px solid var(--border);
   box-shadow: 0 2px 12px rgba(0,0,0,0.05);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out, border-color 0.2s ease-out;
   position: relative;
   overflow: hidden;
 }
@@ -301,7 +301,7 @@ html[data-theme="dark"] .section-title { color: #ffffff; }
   inset: 0;
   background: linear-gradient(135deg, rgba(79,70,229,0.04), rgba(124,58,237,0.04));
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.2s ease-out;
   border-radius: 20px;
 }
 


### PR DESCRIPTION
Fixes #625

## Problem
The hover animation on the four feature cards (Study Materials, Previous Papers, Senior Guidance, Exam Feedback) used a 0.3s transition, which felt sluggish and unresponsive.

## Fix
Reduced the transition duration on `.feature-card` and its `::before` glow overlay from `0.3s ease` to `0.2s ease-out`, bringing it within the recommended 150–250ms range for snappier feedback while keeping the motion smooth.

## Changes
- `client/src/pages/Home.css`
  - `.feature-card`: `transition` duration 0.3s → 0.2s, easing `ease` → `ease-out`
  - `.feature-card::before`: `transition` duration 0.3s → 0.2s, easing `ease` → `ease-out`

## Scope
Only the feature card hover styles were changed. The visually similar `.step` cards in the "How It Works" section were intentionally left untouched, since the issue is specific to the feature cards.

## Testing
Verified the hover effect visually in the browser — feels noticeably more responsive while still smooth, consistent across all four cards.